### PR TITLE
Update build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=34.1.0", "wheel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-# Runtime dependencies
-
-.
+-r requirements/build.txt
+-r requirements/runtime.txt

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,2 @@
+setuptools>=34.1.0
+wheel

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,0 +1,5 @@
+matplotlib
+numpy
+pillow-simd
+pyyaml
+scipy

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import findall, find_packages, setup
 from pkg_resources import get_distribution, DistributionNotFound
+import sys
 
 
 def get_dist(pkgname):
@@ -44,6 +45,85 @@ setup_kwargs = dict(
     test_suite='tests',
     install_requires=requirements,
 )
+
+
+def parse_requirements(fname='requirements.txt', with_version=False):
+    """
+    Parse the package dependencies listed in a requirements file but strips
+    specific versioning information.
+
+    Args:
+        fname (str): path to requirements file
+        with_version (bool, default=False): if true include version specs
+
+    Returns:
+        List[str]: list of requirements items
+
+    CommandLine:
+        python -c "import setup; print(setup.parse_requirements())"
+        python -c "import setup; print(chr(10).join(setup.parse_requirements(with_version=True)))"
+    """
+    from os.path import exists
+    import re
+
+    require_fpath = fname
+
+    def parse_line(line):
+        """
+        Parse information from a line in a requirements text file
+        """
+        if line.startswith('-r '):
+            # Allow specifying requirements in other files
+            target = line.split(' ')[1]
+            for info in parse_require_file(target):
+                yield info
+        else:
+            info = {'line': line}
+            if line.startswith('-e '):
+                info['package'] = line.split('#egg=')[1]
+            else:
+                # Remove versioning from the package
+                pat = '(' + '|'.join(['>=', '==', '>']) + ')'
+                parts = re.split(pat, line, maxsplit=1)
+                parts = [p.strip() for p in parts]
+
+                info['package'] = parts[0]
+                if len(parts) > 1:
+                    op, rest = parts[1:]
+                    if ';' in rest:
+                        # Handle platform specific dependencies
+                        # http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies
+                        version, platform_deps = map(str.strip, rest.split(';'))
+                        info['platform_deps'] = platform_deps
+                    else:
+                        version = rest  # NOQA
+                    info['version'] = (op, version)
+            yield info
+
+    def parse_require_file(fpath):
+        with open(fpath, 'r') as f:
+            for line in f.readlines():
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    for info in parse_line(line):
+                        yield info
+
+    def gen_packages_items():
+        if exists(require_fpath):
+            for info in parse_require_file(require_fpath):
+                parts = [info['package']]
+                if with_version and 'version' in info:
+                    parts.extend(info['version'])
+                if not sys.version.startswith('3.4'):
+                    # apparently package_deps are broken in 3.4
+                    platform_deps = info.get('platform_deps')
+                    if platform_deps is not None:
+                        parts.append(';' + platform_deps)
+                item = ''.join(parts)
+                yield item
+
+    packages = list(gen_packages_items())
+    return packages
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -15,16 +15,6 @@ def find_scripts():
     return findall('scripts')
 
 
-requirements = [
-    'pyyaml',
-    'numpy',
-    'scipy',
-    'matplotlib',
-]
-pillow_req = 'pillow-simd' if get_dist('pillow-simd') is not None else 'pillow'
-requirements.append(pillow_req)
-
-
 setup_kwargs = dict(
     name='wbia-brambox',
     author='EAVISE, WildMe Developers',
@@ -43,7 +33,6 @@ setup_kwargs = dict(
     packages=find_packages(),
     scripts=find_scripts(),
     test_suite='tests',
-    install_requires=requirements,
 )
 
 
@@ -127,4 +116,13 @@ def parse_requirements(fname='requirements.txt', with_version=False):
 
 
 if __name__ == '__main__':
-    setup(**setup_kwargs)
+    install_requires = parse_requirements('requirements/runtime.txt')
+    extras_require = {
+        'all': parse_requirements('requirements.txt'),
+        'runtime': parse_requirements('requirements/runtime.txt'),
+        'build': parse_requirements('requirements/build.txt'),
+    }
+
+    setup(
+        install_requires=install_requires, extras_require=extras_require, **setup_kwargs
+    )


### PR DESCRIPTION
- Add parse_requirements in setup.py

  In preparation for using requirements files.

- Add requirements files build and runtime

  Parse requirements files and add them to `setup`.

- Add build requirements to pyproject.toml
